### PR TITLE
Updating ufo3 branch of defcon to drop robofab

### DIFF
--- a/Lib/defcon/objects/component.py
+++ b/Lib/defcon/objects/component.py
@@ -180,7 +180,7 @@ class Component(BaseObject):
         """
         Draw the component with **pen**.
         """
-        from robofab.pens.adapterPens import PointToSegmentPen
+        from ufoLib.pointPen import PointToSegmentPen
         pointPen = PointToSegmentPen(pen)
         self.drawPoints(pointPen)
 

--- a/Lib/defcon/objects/contour.py
+++ b/Lib/defcon/objects/contour.py
@@ -267,6 +267,7 @@ class Contour(BaseObject):
         This will post *Contour.WindingDirectionChanged*,
         *Contour.PointsChanged* and *Contour.Changed* notifications.
         """
+        # No ufoLib analogue to ReverseContourPointPen
         from robofab.pens.reverseContourPointPen import ReverseContourPointPen
         oldDirection = self.clockwise
         # put the current points in another contour
@@ -584,7 +585,7 @@ class Contour(BaseObject):
         """
         Draw the contour with **pen**.
         """
-        from robofab.pens.adapterPens import PointToSegmentPen
+        from ufoLib.pointPen import PointToSegmentPen
         pointPen = PointToSegmentPen(pen)
         self.drawPoints(pointPen)
 

--- a/Lib/defcon/objects/font.py
+++ b/Lib/defcon/objects/font.py
@@ -1318,6 +1318,7 @@ class Font(BaseObject):
                     setattr(self.info, infoAttr, value)
 
     def _convertToFormatVersion1RoboFabData(self, libCopy):
+        # no ufoLib analogue. should this be re-written?
         from robofab.tools.fontlabFeatureSplitter import splitFeaturesForFontLab
         # features
         features = self.features.text

--- a/Lib/defcon/objects/glyph.py
+++ b/Lib/defcon/objects/glyph.py
@@ -356,7 +356,7 @@ class Glyph(BaseObject):
         """
         Draw the glyph with **pen**.
         """
-        from robofab.pens.adapterPens import PointToSegmentPen
+        from ufoLib.pointPen import PointToSegmentPen
         pointPen = PointToSegmentPen(pen)
         self.drawPoints(pointPen)
 
@@ -387,7 +387,7 @@ class Glyph(BaseObject):
         """
         Get the pen used to draw into this glyph.
         """
-        from robofab.pens.adapterPens import SegmentToPointPen
+        from ufoLib.pointPen import SegmentToPointPen
         return SegmentToPointPen(self.getPointPen())
 
     def getPointPen(self):

--- a/Lib/defcon/pens/decomposeComponentPointPen.py
+++ b/Lib/defcon/pens/decomposeComponentPointPen.py
@@ -1,4 +1,5 @@
 from defcon.pens.glyphObjectPointPen import GlyphObjectPointPen
+# no ufoLib analogue for TransformPointPen
 from robofab.pens.adapterPens import TransformPointPen
 from defcon.objects.component import _defaultTransformation
 

--- a/Lib/defcon/tools/booleanOperations/flatten.py
+++ b/Lib/defcon/tools/booleanOperations/flatten.py
@@ -1,9 +1,6 @@
 import math
-from fontTools.pens.basePen import BasePen
 from fontTools.misc import bezierTools
 from fontTools.pens.basePen import decomposeQuadraticSegment
-from robofab.pens.reverseContourPointPen import ReverseContourPointPen
-from robofab.pens.adapterPens import PointToSegmentPen
 
 """
 To Do:

--- a/documentation/source/index.rst
+++ b/documentation/source/index.rst
@@ -54,8 +54,9 @@ Objects
 Dependencies
 ^^^^^^^^^^^^
 
-* `FontTools <http://fonttools.sf.net>`_
+* `FontTools <https://github.com/behdad/fonttools>`_
 * `RoboFab <http://robofab.com>`_
+* `ufoLib <https://github.com/unified-font-object/ufoLib>`_
 
 
 Indices and tables

--- a/setup.py
+++ b/setup.py
@@ -7,13 +7,19 @@ try:
     import fontTools
 except:
     print "*** Warning: defcon requires FontTools, see:"
-    print "    fonttools.sf.net"
+    print "    github.com/behdad/fonttools"
 
 try:
     import robofab
 except:
     print "*** Warning: defcon requires RoboFab, see:"
     print "    robofab.com"
+    
+try:
+    import ufoLib
+except:
+    print "*** Warning: defcon requires ufoLib, see:"
+    print "    github.com/unified-font-object/ufoLib"
 
 if "sdist" in sys.argv:
     import os


### PR DESCRIPTION
This switches defcon to use ufoLib; this works for everything except
that defcon calls on:

robofab.tools.fontlabFeatureSplitter
TransformPointPen
ReverseContourPointPen

The fontLabFeature splitter should likely be re-written somewhere
(fontParts?), and those two pens could be added to ufoLib, but I don’t
know what you want to do with them (new pen module, fontParts, put them
in ufoLib) so I have kept the robofab dependency for defcon for these
things.