### PR TITLE
objects.font: fix __iter__ method raising AttributeError

### DIFF
--- a/Lib/defcon/objects/font.py
+++ b/Lib/defcon/objects/font.py
@@ -209,7 +209,8 @@ class Font(BaseObject):
         return self._glyphSet.insertGlyph(glyph, name=name)
 
     def __iter__(self):
-        return iter(self._glyphSet.values())
+        for name in self._glyphSet.keys():
+            yield self._glyphSet[name]
 
     def __getitem__(self, name):
         return self._glyphSet[name]


### PR DESCRIPTION
as reported by @mashabow, `Layer` object only has 'keys' method, and no 'values'.
https://github.com/typesupply/defcon/pull/48/files/a9c0c9f961fcc6064e14c5d629db09fd20b67ca7#r63487919

We can simply `yield` the values by iterating on the layer's `keys()`.

Or we could add a `values()` method to Layers, like this:

E.g.:
```python
def values(self):
    return [self[name] for name in self.keys()]
```