### PR TITLE
fix AttributeError with `self._identifier` on Anchor and Guideline classes

### DIFF
--- a/Lib/defcon/objects/anchor.py
+++ b/Lib/defcon/objects/anchor.py
@@ -186,7 +186,7 @@ class Anchor(BaseDictObject):
 
     def _set_identifier(self, value):
         # don't allow overwritting an existing identifier
-        if self._identifier is not None:
+        if self.identifier is not None:
             return
         oldIdentifier = self.identifier
         if value == oldIdentifier:

--- a/Lib/defcon/objects/guideline.py
+++ b/Lib/defcon/objects/guideline.py
@@ -225,7 +225,7 @@ class Guideline(BaseDictObject):
 
     def _set_identifier(self, value):
         # don't allow overwritting an existing identifier
-        if self._identifier is not None:
+        if self.identifier is not None:
             return
         oldIdentifier = self.identifier
         if value == oldIdentifier:


### PR DESCRIPTION
a minor issue introduced in 71516c313c1f82cffe66ba1b42b311ec0450b34d