### PR TITLE
[ufo3] fix tests and replace guideline.fontInfo by guideline.font

### DIFF
--- a/Lib/defcon/objects/glyph.py
+++ b/Lib/defcon/objects/glyph.py
@@ -841,7 +841,7 @@ class Glyph(BaseObject):
             guideline = self.instantiateGuideline(guidelineDict=guideline)
         assert guideline.glyph in (self, None), "This guideline belongs to another glyph."
         if guideline.glyph is None:
-            assert guideline.fontInfo is None, "This guideline belongs to a font."
+            assert guideline.font is None, "This guideline belongs to a font."
         if guideline.glyph is None:
             if guideline.identifier is not None:
                 identifiers = self._identifiers

--- a/Lib/defcon/test/objects/test_anchor.py
+++ b/Lib/defcon/test/objects/test_anchor.py
@@ -84,9 +84,17 @@ class AnchorTest(unittest.TestCase):
 
     def test_identifier(self):
         self.assertIsNone(self.anchor.identifier)
-        self.anchor.generateIdentifier()
+        identifier = self.anchor.generateIdentifier()
+        self.assertEqual(identifier, self.anchor.identifier)
         self.assertIsNotNone(self.anchor.identifier)
+
+    def test_identifier_set(self):
+        self.assertIsNone(self.anchor.identifier)
         self.anchor.identifier = "foo"
+        self.assertEqual(self.anchor.identifier, "foo")
+        self.anchor.identifier = "bar"
+        self.assertEqual(self.anchor.identifier, "foo")
+        self.anchor.identifier = None
         self.assertEqual(self.anchor.identifier, "foo")
 
     def test_instance(self):

--- a/Lib/defcon/test/objects/test_component.py
+++ b/Lib/defcon/test/objects/test_component.py
@@ -105,10 +105,12 @@ class ComponentTest(unittest.TestCase):
         )
 
     def test_identifier(self):
+        self.assertIsNone(self.component.identifier)
         self.component.identifier = "component 1"
         self.assertEqual(self.component.identifier, "component 1")
 
     def test_identifiers(self):
+        self.assertEqual(sorted(self.glyph.identifiers), [])
         self.component.identifier = "component 1"
         self.assertEqual(sorted(self.glyph.identifiers), ["component 1"])
 
@@ -124,13 +126,13 @@ class ComponentTest(unittest.TestCase):
         self.assertEqual(sorted(glyph.identifiers),
                          ["component 1", "component 2"])
         component.identifier = "not component 2 anymore"
-        self.assertEqual(component.identifier,
-                         "not component 2 anymore")
+        self.assertEqual(component.identifier, "component 2")
         self.assertEqual(sorted(glyph.identifiers),
-                         ["component 1", "not component 2 anymore"])
+                         ["component 1", "component 2"])
         component.identifier = None
+        self.assertEqual(component.identifier, "component 2")
         self.assertEqual(sorted(glyph.identifiers),
-                         ["component 1"])
+                         ["component 1", "component 2"])
 
 
 class ComponentNotificationTest(unittest.TestCase):

--- a/Lib/defcon/test/objects/test_contour.py
+++ b/Lib/defcon/test/objects/test_contour.py
@@ -372,13 +372,11 @@ class ContourTest(unittest.TestCase):
         contour.identifier = "contour 2"
         self.assertEqual(sorted(glyph.identifiers), ["contour 1", "contour 2"])
         contour.identifier = "not contour 2 anymore"
-        self.assertEqual(contour.identifier, "not contour 2 anymore")
-        self.assertEqual(sorted(glyph.identifiers),
-                         ["contour 1", "not contour 2 anymore"])
+        self.assertEqual(contour.identifier, "contour 2")
+        self.assertEqual(sorted(glyph.identifiers), ["contour 1", "contour 2"])
         contour.identifier = None
-        self.assertIsNone(contour.identifier)
-        self.assertEqual(sorted(glyph.identifiers), ["contour 1"])
-
+        self.assertEqual(contour.identifier, "contour 2")
+        self.assertEqual(sorted(glyph.identifiers), ["contour 1", "contour 2"])
 
 if __name__ == "__main__":
     unittest.main()

--- a/Lib/defcon/test/objects/test_imageSet.py
+++ b/Lib/defcon/test/objects/test_imageSet.py
@@ -1,7 +1,9 @@
+from __future__ import unicode_literals
 import unittest
 import os
 from ufoLib import UFOReader
 from defcon import Font
+from defcon.objects.imageSet import fileNameValidator
 from defcon.test.testTools import (
     getTestFontPath, getTestFontCopyPath, makeTestFontCopy,
     tearDownTestFontCopy)
@@ -168,6 +170,37 @@ class ImageSetTest(unittest.TestCase):
         image = font.images["image 1.png"]
         self.assertEqual(image, newImageData)
         tearDownTestFontCopy()
+
+    def test_fileNameValidator(self):
+        self.assertTrue(fileNameValidator('a'))
+        self.assertTrue(fileNameValidator('A_'))
+        self.assertTrue(fileNameValidator('A_E_'))
+        self.assertTrue(fileNameValidator('A_e'))
+        self.assertTrue(fileNameValidator('ae'))
+        self.assertTrue(fileNameValidator('aE_'))
+        self.assertTrue(fileNameValidator('a.alt'))
+        self.assertTrue(fileNameValidator('A_.alt'))
+        self.assertTrue(fileNameValidator('A_.A_lt'))
+        self.assertTrue(fileNameValidator('A_.aL_t'))
+        self.assertTrue(fileNameValidator('A_.alT_'))
+        self.assertTrue(fileNameValidator('T__H_'))
+        self.assertTrue(fileNameValidator('T__h'))
+        self.assertTrue(fileNameValidator('t_h'))
+        self.assertTrue(fileNameValidator('F__F__I_'))
+        self.assertTrue(fileNameValidator('f_f_i'))
+        self.assertTrue(fileNameValidator('A_acute_V_.swash'))
+        self.assertTrue(fileNameValidator('_notdef'))
+        self.assertTrue(fileNameValidator('_con'))
+        self.assertTrue(fileNameValidator('C_O_N_'))
+        self.assertTrue(fileNameValidator('_con.alt'))
+        self.assertTrue(fileNameValidator('alt._con'))
+        self.assertTrue(fileNameValidator('A_bC_dE_f'))
+
+        self.assertFalse(fileNameValidator(b'A'))
+        self.assertFalse(fileNameValidator('A'*256))
+        self.assertFalse(fileNameValidator('A'))
+        self.assertFalse(fileNameValidator('con'))
+        self.assertFalse(fileNameValidator('a/alt'))
 
 if __name__ == "__main__":
     unittest.main()

--- a/Lib/defcon/test/objects/test_layer.py
+++ b/Lib/defcon/test/objects/test_layer.py
@@ -301,7 +301,7 @@ class LayerTest(unittest.TestCase):
         self.assertEqual(component.dispatcher, font.dispatcher)
         glyph = font.layers["Layer 1"]["A"]
         guideline = glyph.guidelines[0]
-        self.assertEqual(guideline.getParent(), glyph)
+        self.assertEqual(guideline.getParent(), font)
         self.assertEqual(guideline.dispatcher, font.dispatcher)
 
     def test_glyph_dispatcher_new(self):
@@ -328,7 +328,7 @@ class LayerTest(unittest.TestCase):
         self.assertEqual(anchor.dispatcher, font.dispatcher)
         guideline = Guideline()
         glyph.appendGuideline(guideline)
-        self.assertEqual(guideline.getParent(), glyph)
+        self.assertEqual(guideline.getParent(), font)
         self.assertEqual(guideline.dispatcher, font.dispatcher)
 
     def test_glyph_dispatcher_inserted(self):


### PR DESCRIPTION
Requires https://github.com/unified-font-object/ufoLib/pull/39

* tests: guideline.getParent() can return guideline.font since e87e0c
* tests: use unicode_literals in tests_imageSet
* tests: update identifier tests to match 71516c
* glyph: replace guideline.fontInfo by guideline.font as in e87e0c