### PR TITLE
objects.glyph: Add topMargin and bottomMargin

### DIFF
--- a/Lib/defcon/objects/glyph.py
+++ b/Lib/defcon/objects/glyph.py
@@ -300,6 +300,46 @@ class Glyph(BaseObject):
 
     rightMargin = property(_get_rightMargin, _set_rightMargin, doc="The right margin of the glyph. Setting this posts *Glyph.WidthChanged* and *Glyph.Changed* notifications among others.")
 
+    def _get_bottomMargin(self):
+        bounds = self.bounds
+        if bounds is None:
+            return None
+        xMin, yMin, xMax, yMax = bounds
+        return yMin
+
+    def _set_bottomMargin(self, value):
+        bounds = self.bounds
+        if bounds is None:
+            return
+        xMin, yMin, xMax, yMax = bounds
+        oldValue = yMin
+        diff = value - yMin
+        if value != oldValue:
+            self.move((0, diff))
+            self.height += diff
+            self.dirty = True
+
+    bottomMargin = property(_get_bottomMargin, _set_bottomMargin, doc="The bottom margin of the glyph. Setting this post *Glyph.HeightChanged* and *Glyph.Changed* notifications among others.")
+
+    def _get_topMargin(self):
+        bounds = self.bounds
+        if bounds is None:
+            return None
+        xMin, yMin, xMax, yMax = bounds
+        return self._height - yMax
+
+    def _set_topMargin(self, value):
+        bounds = self.bounds
+        if bounds is None:
+            return
+        xMin, yMin, xMax, yMax = bounds
+        oldValue = self._height - yMax
+        if oldValue != value:
+            self.height = yMax + value
+            self.dirty = True
+
+    topMargin = property(_get_topMargin, _set_topMargin, doc="The top margin of the glyph. Setting this posts *Glyph.HeightChanged* and *Glyph.Changed* notifications among others.")
+
     # width
 
     def _get_width(self):

--- a/Lib/defcon/test/objects/test_glyph.py
+++ b/Lib/defcon/test/objects/test_glyph.py
@@ -153,6 +153,38 @@ class GlyphTest(unittest.TestCase):
         self.assertEqual(glyph.width, 800)
         self.assertTrue(glyph.dirty)
 
+    def test_bottomMargin_get(self):
+        font = Font(getTestFontPath())
+        glyph = font["A"]
+        self.assertEqual(glyph.bottomMargin, 0)
+        glyph = font["B"]
+        self.assertEqual(glyph.bottomMargin, 0)
+
+    def test_bottomMargin_set(self):
+        font = Font(getTestFontPath())
+        glyph = font["A"]
+        glyph.bottomMargin = 100
+        self.assertEqual(glyph.bottomMargin, 100)
+        self.assertEqual(glyph.height, 600)
+        self.assertTrue(glyph.dirty)
+
+    def test_topMargin_get(self):
+        from defcon.test.testTools import getTestFontPath
+        from defcon.objects.font import Font
+        font = Font(getTestFontPath())
+        glyph = font["A"]
+        self.assertEqual(glyph.topMargin, -200)
+
+    def test_topMargin_set(self):
+        from defcon.test.testTools import getTestFontPath
+        from defcon.objects.font import Font
+        font = Font(getTestFontPath())
+        glyph = font["A"]
+        glyph.topMargin = 100
+        self.assertEqual(glyph.topMargin, 100)
+        self.assertEqual(glyph.height, 800)
+        self.assertTrue(glyph.dirty)
+
     def test_width_get(self):
         font = Font(getTestFontPath())
         glyph = font["A"]


### PR DESCRIPTION
When editing fonts for vertical layout one should be able to use glyph.topMargin and glyph.bottomMargin just like they would with glyph.rightMargin or glyph.leftMargin in horizontal layout.