### PR TITLE
font: don't set font when instantiating guideline

### DIFF
--- a/Lib/defcon/objects/font.py
+++ b/Lib/defcon/objects/font.py
@@ -892,10 +892,7 @@ class Font(BaseObject):
     guidelines = property(_get_guidelines, _set_guidelines, doc="An ordered list of :class:`Guideline` objects stored in the font. Setting this will post a *Font.Changed* notification along with any notifications posted by the :py:meth:`Font.appendGuideline` and :py:meth:`Font.clearGuidelines` methods.")
 
     def instantiateGuideline(self, guidelineDict=None):
-        guideline = self._guidelineClass(
-            font=self,
-            guidelineDict=guidelineDict
-        )
+        guideline = self._guidelineClass(guidelineDict=guidelineDict)
         return guideline
 
     def beginSelfGuidelineNotificationObservation(self, guideline):

--- a/Lib/defcon/objects/font.py
+++ b/Lib/defcon/objects/font.py
@@ -903,8 +903,8 @@ class Font(BaseObject):
     def endSelfGuidelineNotificationObservation(self, guideline):
         if guideline.dispatcher is None:
             return
-        guideline.endSelfNotificationObservation()
         guideline.removeObserver(observer=self, notification="Guideline.Changed")
+        guideline.endSelfNotificationObservation()
 
     def appendGuideline(self, guideline):
         """

--- a/Lib/defcon/objects/guideline.py
+++ b/Lib/defcon/objects/guideline.py
@@ -56,10 +56,10 @@ class Guideline(BaseDictObject):
     # --------------
 
     def getParent(self):
-        if self._font is not None:
-            return self.font
-        elif self._glyph is not None:
+        if self._glyph is not None:
             return self.glyph
+        elif self._font is not None:
+            return self.font
         return None
 
     def _get_font(self):

--- a/Lib/defcon/test/objects/test_font.py
+++ b/Lib/defcon/test/objects/test_font.py
@@ -316,6 +316,7 @@ class FontTest(unittest.TestCase):
     def test_beginSelfGuidelineNotificationObservation(self):
         font = Font(getTestFontPath())
         guideline = font.instantiateGuideline()
+        guideline.font = font
         self.assertFalse(guideline.dispatcher.hasObserver(
             font, "Guideline.Changed", guideline))
         font.beginSelfGuidelineNotificationObservation(guideline)
@@ -325,6 +326,7 @@ class FontTest(unittest.TestCase):
     def test_endSelfGuidelineNotificationObservation(self):
         font = Font(getTestFontPath())
         guideline = font.instantiateGuideline()
+        guideline.font = font
         font.beginSelfGuidelineNotificationObservation(guideline)
         self.assertTrue(guideline.hasObserver(
             font, "Guideline.Changed"))

--- a/Lib/defcon/test/objects/test_layer.py
+++ b/Lib/defcon/test/objects/test_layer.py
@@ -301,7 +301,7 @@ class LayerTest(unittest.TestCase):
         self.assertEqual(component.dispatcher, font.dispatcher)
         glyph = font.layers["Layer 1"]["A"]
         guideline = glyph.guidelines[0]
-        self.assertEqual(guideline.getParent(), font)
+        self.assertEqual(guideline.getParent(), glyph)
         self.assertEqual(guideline.dispatcher, font.dispatcher)
 
     def test_glyph_dispatcher_new(self):
@@ -328,7 +328,7 @@ class LayerTest(unittest.TestCase):
         self.assertEqual(anchor.dispatcher, font.dispatcher)
         guideline = Guideline()
         glyph.appendGuideline(guideline)
-        self.assertEqual(guideline.getParent(), font)
+        self.assertEqual(guideline.getParent(), glyph)
         self.assertEqual(guideline.dispatcher, font.dispatcher)
 
     def test_glyph_dispatcher_inserted(self):


### PR DESCRIPTION
This patch is similar to 0be21f696422af52984735cf44c4b212e172294a but for font guidelines instead of glyph.

r? @typesupply 