### PR TITLE
glyph: one may insert guidelines with the same x, y or angle

### DIFF
--- a/Lib/defcon/objects/glyph.py
+++ b/Lib/defcon/objects/glyph.py
@@ -914,7 +914,7 @@ class Glyph(BaseObject):
 
         This will post a *Glyph.Changed* notification.
         """
-        assert guideline not in self.guidelines
+        assert id(guideline) not in [id(guide) for guide in self.guidelines]
         if not isinstance(guideline, self._guidelineClass):
             guideline = self.instantiateGuideline(guidelineDict=guideline)
         assert guideline.glyph in (self, None), "This guideline belongs to another glyph."


### PR DESCRIPTION
In some cases a guideline may be on top of another, even though this is not good it is valid and shouldn’t raise and AssertionError.