### PR TITLE
[layer/layerSet] use py23.tounicode(); unicode() built-in is gone in py3

### DIFF
--- a/Lib/defcon/objects/layer.py
+++ b/Lib/defcon/objects/layer.py
@@ -2,6 +2,7 @@ from __future__ import absolute_import
 import os
 import weakref
 from fontTools.misc.arrayTools import unionRect, calcBounds
+from fontTools.misc.py23 import tounicode
 from defcon.objects.base import BaseObject
 from defcon.objects.glyph import Glyph
 from defcon.objects.lib import Lib
@@ -307,6 +308,7 @@ class Layer(BaseObject):
     # name
 
     def _set_name(self, value):
+        value = tounicode(value)
         oldName = self._name
         if oldName != value:
             self._name = value

--- a/Lib/defcon/objects/layerSet.py
+++ b/Lib/defcon/objects/layerSet.py
@@ -293,8 +293,8 @@ class LayerSet(BaseObject):
                         # this will be handled by the creation of the glyph set
                         continue
                     # both are in the file, so do the renames
-                    writer.renameGlyphSet(newDefault, unicode(newDefault), defaultLayer=True)
-                    writer.renameGlyphSet(oldDefault, unicode(oldDefault), defaultLayer=False)
+                    writer.renameGlyphSet(newDefault, newDefault, defaultLayer=True)
+                    writer.renameGlyphSet(oldDefault, oldDefault, defaultLayer=False)
                 elif action == "new":
                     # this will be handled by the creation of the glyph set
                     pass


### PR DESCRIPTION
Instead of converting layer names to unicode just before sending them to ufoLib, I think it's better we ensure they are unicode strings at the time they are set, i.e. in the `_set_name` property setter.

The `tounicode` function uses by default 'ascii' when decoding bytes to unicode. I think it's fine to leave that as is. If users want to set a layer name to anything that non-ascii, then they must use unicode literals (e.g. u"").

For consistency, we should probably do the same (normalizing string input to unicode) for all the other string-y attributes (e.g. glyph.name, etc.).

/cc @typemytype @adrientetar 