### PR TITLE
use Glyph.controlPointBounds to calculate Layer.controlPointBounds

### DIFF
--- a/Lib/defcon/tools/representations.py
+++ b/Lib/defcon/tools/representations.py
@@ -8,34 +8,14 @@ from fontTools.misc.arrayTools import unionRect
 # -----
 
 def glyphBoundsRepresentationFactory(glyph):
-    # base glyph
     pen = BoundsPen(glyph.getParent())
     glyph.draw(pen)
-    bounds = pen.bounds
-    # components
-    for component in glyph.components:
-        b = component.bounds
-        if b is not None:
-            if bounds is None:
-                bounds = b
-            else:
-                bounds = unionRect(bounds, b)
-    return bounds
+    return pen.bounds
 
 def glyphControlPointBoundsRepresentationFactory(glyph):
-    # base glyph
     pen = ControlBoundsPen(glyph.getParent())
     glyph.draw(pen)
-    bounds = pen.bounds
-    # components
-    for component in glyph.components:
-        b = component.controlPointBounds
-        if b is not None:
-            if bounds is None:
-                bounds = b
-            else:
-                bounds = unionRect(bounds, b)
-    return bounds
+    return pen.bounds
 
 # -------
 # Contour


### PR DESCRIPTION
I noticed that the `Layer.controlPointBounds` property getter is not using the corresponding `Glyph.controlPointBounds`, but is instead doing the work all by itself for no apparent reason; on the other hand, `Layer.bounds` takes advantage of `Glyph.bounds`.
So I made the two getters consistent with each other, and have the layer's control point bounds be determined directly by the glyphs' ones.

I also noticed that the two functions that are used to compute a glyph's bounds and controlPointBounds (in `representations.py`) are computing again the bound for each component, but that's not necessary, since the fontTools `BoundsPen` and `ControlBoundsPen` inherit from `BasePen`, which has a `addComponent` method that takes care of transforming/drawing the components.

/cc @typesupply @adrientetar 