### PR TITLE
Font: make rename an atomic glyphOrder op

### DIFF
--- a/Lib/defcon/objects/base.py
+++ b/Lib/defcon/objects/base.py
@@ -1,6 +1,5 @@
 from __future__ import absolute_import
 import weakref
-from defcon.tools.notifications import NotificationCenter
 import pickle
 
 class BaseObject(object):
@@ -465,8 +464,6 @@ class BaseObject(object):
                 continue
             data[key] = getter(key)
         return data
-
-
 
 
 class BaseDictObject(dict, BaseObject):

--- a/Lib/defcon/objects/component.py
+++ b/Lib/defcon/objects/component.py
@@ -353,7 +353,6 @@ class Component(BaseObject):
         layer.removeObserver(self, "Layer.GlyphAdded")
 
     def baseGlyphNameChangedNotificationCallback(self, notification):
-        oldName = notification.data["oldValue"]
         newName = notification.data["newValue"]
         layer = self.layer
         notBaseGlyph = layer[newName]

--- a/Lib/defcon/objects/contour.py
+++ b/Lib/defcon/objects/contour.py
@@ -527,7 +527,7 @@ class Contour(BaseObject):
             x = x1 + (x2 - x1) * t
             y = y1 + (y2 - y1) * t
             pointsToInsert = [((x, y), "line", False)]
-            insertionPoint =  (x, y)
+            insertionPoint = (x, y)
             pointWillBeSmooth = False
         elif segmentType == "curve":
             pt1, pt2, pt3, pt4 = segment

--- a/Lib/defcon/objects/dataSet.py
+++ b/Lib/defcon/objects/dataSet.py
@@ -159,7 +159,7 @@ class DataSet(BaseObject):
         added = []
         deleted = []
         for fileName in set(filesOnDisk) - set(self.fileNames):
-            if not fileName in self._scheduledForDeletion:
+            if fileName not in self._scheduledForDeletion:
                 added.append(fileName)
             elif not self._scheduledForDeletion[fileName]["onDisk"]:
                 added.append(fileName)

--- a/Lib/defcon/objects/font.py
+++ b/Lib/defcon/objects/font.py
@@ -622,17 +622,23 @@ class Font(BaseObject):
         by subclasses as needed.
         """
         order = self.glyphOrder
+        index = None
+        if removedGlyph is not None:
+            # if removed glyph is present, store its index.
+            # we'll either replace it with added glyph or delete it
+            try:
+                index = order.index(removedGlyph)
+            except ValueError:
+                pass
         if addedGlyph is not None:
             if addedGlyph not in order:
-                order.append(addedGlyph)
-        elif removedGlyph is not None:
-            if removedGlyph in order:
-                count = order.count(removedGlyph)
-                if count == 1:
-                    order.remove(removedGlyph)
+                if index is not None:
+                    order[index] = addedGlyph
+                    index = None
                 else:
-                    for i in range(count):
-                        order.remove(removedGlyph)
+                    order.append(addedGlyph)
+        if index is not None:
+            del order[index]
         self.glyphOrder = order
 
     # -------
@@ -1052,9 +1058,8 @@ class Font(BaseObject):
             if oldName in layer:
                 oldStillExists = True
                 break
-        if not oldStillExists:
-            self.updateGlyphOrder(removedGlyph=oldName)
-        self.updateGlyphOrder(addedGlyph=newName)
+        removedGlyph = oldName if not oldStillExists else None
+        self.updateGlyphOrder(addedGlyph=newName, removedGlyph=removedGlyph)
 
     def _guidelineChanged(self, notification):
         self.postNotification("Font.GuidelinesChanged")

--- a/Lib/defcon/objects/font.py
+++ b/Lib/defcon/objects/font.py
@@ -624,6 +624,9 @@ class Font(BaseObject):
                 index = order.index(removedGlyph)
             except ValueError:
                 pass
+            else:
+                if removedGlyph == addedGlyph:
+                    return
         if addedGlyph is not None:
             if addedGlyph not in order:
                 if index is not None:

--- a/Lib/defcon/objects/font.py
+++ b/Lib/defcon/objects/font.py
@@ -1,16 +1,11 @@
 from __future__ import absolute_import
 import os
 import re
-import weakref
-from copy import deepcopy
 import tempfile
 import shutil
-from fontTools.misc.arrayTools import unionRect
 from ufoLib import UFOReader, UFOWriter
-from defcon.errors import DefconError
 from defcon.objects.base import BaseObject
 from defcon.objects.layerSet import LayerSet
-from defcon.objects.layer import Layer
 from defcon.objects.info import Info
 from defcon.objects.kerning import Kerning
 from defcon.objects.groups import Groups
@@ -124,7 +119,6 @@ class Font(BaseObject):
         self._features = None
         self._lib = None
         self._kerningGroupConversionRenameMaps = None
-
 
         self._layers = self.instantiateLayerSet()
         self.beginSelfLayerSetNotificationObservation()

--- a/Lib/defcon/objects/glyph.py
+++ b/Lib/defcon/objects/glyph.py
@@ -1,7 +1,6 @@
 from __future__ import absolute_import
 import weakref
 from warnings import warn
-from fontTools.misc import arrayTools
 from fontTools.misc.py23 import basestring
 from defcon.objects.base import BaseObject
 from defcon.objects.contour import Contour
@@ -1259,7 +1258,6 @@ class Glyph(BaseObject):
     # Serialization/Deserialization
     # -----------------------------
 
-
     def getDataForSerialization(self, **kwargs):
         from functools import partial
 
@@ -1282,9 +1280,9 @@ class Glyph(BaseObject):
         ]
 
         if self._shallowLoadedContours is not None:
-            getters.append( ('_shallowLoadedContours', simple_get) )
+            getters.append(('_shallowLoadedContours', simple_get))
         else:
-            getters.append( ('_contours', serialized_list_get) )
+            getters.append(('_contours', serialized_list_get))
 
         return self._serialize(getters, **kwargs)
 
@@ -1329,7 +1327,7 @@ class Glyph(BaseObject):
             ('_contours', init_set(list_init, self.instantiateContour, set_each(self.appendContour, True))),
             ('components', init_set(list_init, self._componentClass, set_each(self.appendComponent, True))),
             ('guidelines', init_set(list_init, self._guidelineClass, set_attr)),
-            ('anchors',init_set(list_init, self._anchorClass, set_attr)),
+            ('anchors', init_set(list_init, self._anchorClass, set_attr)),
             ('image', init_set(single_init, self.instantiateImage, set_attr))
         )
 

--- a/Lib/defcon/objects/imageSet.py
+++ b/Lib/defcon/objects/imageSet.py
@@ -268,7 +268,7 @@ class ImageSet(BaseObject):
         addedImages = []
         deletedImages = []
         for fileName in set(filesOnDisk) - set(self.fileNames):
-            if not fileName in self._scheduledForDeletion:
+            if fileName not in self._scheduledForDeletion:
                 addedImages.append(fileName)
             elif not self._scheduledForDeletion[fileName]["onDisk"]:
                 addedImages.append(fileName)

--- a/Lib/defcon/objects/layer.py
+++ b/Lib/defcon/objects/layer.py
@@ -1,7 +1,6 @@
 from __future__ import absolute_import
-import os
 import weakref
-from fontTools.misc.arrayTools import unionRect, calcBounds
+from fontTools.misc.arrayTools import unionRect
 from fontTools.misc.py23 import tounicode
 from defcon.objects.base import BaseObject
 from defcon.objects.glyph import Glyph

--- a/Lib/defcon/objects/layerSet.py
+++ b/Lib/defcon/objects/layerSet.py
@@ -480,8 +480,6 @@ class LayerSet(BaseObject):
         return self._serialize(getters, **kwargs)
 
     def setDataFromSerialization(self, data):
-        from functools import partial
-
         if 'layers' not in data:
             return
         for name, data, isDefault in data['layers']:

--- a/Lib/defcon/objects/point.py
+++ b/Lib/defcon/objects/point.py
@@ -1,6 +1,4 @@
 from __future__ import absolute_import
-import weakref
-from defcon.tools.identifiers import makeRandomIdentifier
 
 
 class Point(object):

--- a/Lib/defcon/test/objects/test_font.py
+++ b/Lib/defcon/test/objects/test_font.py
@@ -269,7 +269,7 @@ class FontTest(unittest.TestCase):
         self.assertEqual(font.glyphOrder, [])
         font.glyphOrder = sorted(font.keys())
         self.assertEqual(font.glyphOrder, ["A", "B", "C"])
-        layer = font.layers["public.default"]
+        layer = font.layers.defaultLayer
         layer.newGlyph("X")
         self.assertEqual(sorted(layer.keys()), ["A", "B", "C", "X"])
         self.assertEqual(font.glyphOrder, ["A", "B", "C", "X"])
@@ -277,6 +277,8 @@ class FontTest(unittest.TestCase):
         self.assertEqual(font.glyphOrder, ["A", "B", "C", "X"])
         del layer["X"]
         self.assertEqual(font.glyphOrder, ["A", "B", "C"])
+        layer["B"].name = "Y"
+        self.assertEqual(font.glyphOrder, ["A", "Y", "C"])
 
     def test_updateGlyphOrder_none(self):
         font = Font(getTestFontPath())
@@ -297,6 +299,14 @@ class FontTest(unittest.TestCase):
         self.assertEqual(font.glyphOrder, ["test"])
         font.updateGlyphOrder(removedGlyph="test")
         self.assertEqual(font.glyphOrder, [])
+
+    def test_updateGlyphOrder_rename(self):
+        font = Font(getTestFontPath())
+        self.assertEqual(font.glyphOrder, [])
+        font.glyphOrder = sorted(font.keys())
+        self.assertEqual(font.glyphOrder, ["A", "B", "C"])
+        font.updateGlyphOrder(addedGlyph="new", removedGlyph="B")
+        self.assertEqual(font.glyphOrder, ["A", "new", "C"])
 
     def test_guidelines(self):
         font = Font(getTestFontPath())


### PR DESCRIPTION
Previously when a glyph was renamed, defcon would first remove the old name from the glyphOrder then append the new one. This makes rename a single operation so that **a renamed glyph keeps the same position in the glyphOrder.**

Note: this drops the multiple removal passes from removed glyph name, as it's not necessary. The adding code checks that the glyph name isn't already in the glyph order.

Fixes trufont/trufont#314.

r? @anthrotype 