### PR TITLE
Notifications: reverse the dispatch order

### DIFF
--- a/Lib/defcon/objects/base.py
+++ b/Lib/defcon/objects/base.py
@@ -516,11 +516,11 @@ class BaseDictObject(dict, BaseObject):
     # -----------------------------
 
     def getDataForSerialization(self, **kwargs):
-        deep_get = lambda k: self[k]
+        simple_get = lambda k: self[k]
 
         getters = []
         for k in self.keys():
-            getters.append((k, deep_get))
+            getters.append((k, simple_get))
 
         return self._serialize(getters, **kwargs)
 

--- a/Lib/defcon/objects/contour.py
+++ b/Lib/defcon/objects/contour.py
@@ -706,56 +706,56 @@ class Contour(BaseObject):
 
 class Recorder(object):
     """
-        Records all method calls it receives in a list of tuples in the form of
-        [(:str:command, :list:args, :dict: kwargd)]
+    Records all method calls it receives in a list of tuples in the form of
+    [(:str:command, :list:args, :dict: kwargs)]
 
-        Method calls to be recorded must not start with an underscore.
+    Method calls to be recorded must not start with an underscore.
 
-        This class creates a callable object which can be used like a
-        function: "recorder(target)" because that way calls to all methods
-        that don't start with underscores can be recorded.
+    This class creates a callable object which can be used like a
+    function: "recorder(target)" because that way calls to all methods
+    that don't start with underscores can be recorded.
 
-        This is useful to record the commands of both pen protocols
-        and it may become useful for other things as well, like recording
-        undo commands.
+    This is useful to record the commands of both pen protocols
+    and it may become useful for other things as well, like recording
+    undo commands.
 
-        Example Session PointPen:
+    Example Session PointPen:
 
-        data_glyphA = []
-        recorderPointPen = Recorder(data_glyphA)
-        glyphA.drawPoints(recorderPointPen)
+    data_glyphA = []
+    recorderPointPen = Recorder(data_glyphA)
+    glyphA.drawPoints(recorderPointPen)
 
-        # The point data of the glyph is now stored within data
-        # we can either replay it immediately or take it away and use it
-        # to replay it later
+    # The point data of the glyph is now stored within data
+    # we can either replay it immediately or take it away and use it
+    # to replay it later
 
-        stored_data = pickle.dumps(data_glyphA)
-        restored_data_glyphA = pickle.loads(stored_data)
+    stored_data = pickle.dumps(data_glyphA)
+    restored_data_glyphA = pickle.loads(stored_data)
 
-        player = Recorder(restored_data_glyphA)
-        # The recorder behaves like glyphA.drawPoints
-        player(glyphB)
+    player = Recorder(restored_data_glyphA)
+    # The recorder behaves like glyphA.drawPoints
+    player(glyphB)
 
+    Example Session SegmentPen:
 
-        Example Session SegmentPen:
+    data_glyphA = []
+    recorderPen = Recorder(data_glyphA)
+    glyphA.draw(recorderPen)
 
-        data_glyphA = []
-        recorderPen = Recorder(data_glyphA)
-        glyphA.draw(recorderPen)
-
-        # reuse it immediately
-        # The recorder behaves like glyphA.draw
-        recorderPen(glyphB)
+    # reuse it immediately
+    # The recorder behaves like glyphA.draw
+    recorderPen(glyphB)
     """
     def __init__(self, data=None):
         self.__dict__['_data'] = data if data is not None else []
 
     def __call__(self, target):
-        """ Replay all methof calls this Recorder to target.
-            Public Method(!)
         """
-        for cmd, args, kwds in self._data:
-            getattr(target, cmd)(*args, **kwds)
+        Public API.
+        Replay all method calls to this Recorder to target.
+        """
+        for cmd, args, kwargs in self._data:
+            getattr(target, cmd)(*args, **kwargs)
 
     def __setattr__(self, name, value):
         raise AttributeError('It\'s not allowed to set attributes here.', name)
@@ -763,8 +763,9 @@ class Recorder(object):
     def __getattr__(self, name):
         if name.startswith('_'):
             raise AttributeError(name)
-        def command(*args, **kwds):
-            self._data.append((name, args, kwds))
+
+        def command(*args, **kwargs):
+            self._data.append((name, args, kwargs))
         # cache the method, don't use __setattr__
         self.__dict__[name] = command
         return command

--- a/Lib/defcon/objects/dataSet.py
+++ b/Lib/defcon/objects/dataSet.py
@@ -4,8 +4,6 @@ import weakref
 from ufoLib import UFOReader, UFOLibError
 from defcon.objects.base import BaseObject
 
-pngSignature = "\x89PNG\r\n\x1a\n"
-
 
 class DataSet(BaseObject):
 

--- a/Lib/defcon/objects/font.py
+++ b/Lib/defcon/objects/font.py
@@ -15,6 +15,7 @@ from defcon.objects.imageSet import ImageSet
 from defcon.objects.dataSet import DataSet
 from defcon.objects.guideline import Guideline
 from defcon.tools.notifications import NotificationCenter
+from functools import partial
 
 
 class Font(BaseObject):
@@ -1546,8 +1547,6 @@ class Font(BaseObject):
     # -----------------------------
 
     def getDataForSerialization(self, **kwargs):
-        from functools import partial
-
         simple_get = partial(getattr, self)
         serialize = lambda item: item.getDataForSerialization()
         serialized_get = lambda key: serialize(simple_get(key))
@@ -1575,8 +1574,6 @@ class Font(BaseObject):
         return self._serialize(getters, **kwargs)
 
     def setDataFromSerialization(self, data):
-        from functools import partial
-
         set_attr = partial(setattr, self) # key, data
 
         def single_update(key, data):

--- a/Lib/defcon/objects/info.py
+++ b/Lib/defcon/objects/info.py
@@ -7,6 +7,7 @@ from warnings import warn
 import ufoLib
 from defcon.objects.base import BaseObject
 from copy import copy
+from functools import partial
 
 def _guidelineDeprecation(message=None):
     msg = "Font level guidelines are now handled in the Font object."
@@ -284,12 +285,7 @@ class Info(BaseObject):
     # -----------------------------
 
     def getDataForSerialization(self, **kwargs):
-        from functools import partial
-
         simple_get = partial(getattr, self)
-        # not sure, but these are not necessary
-        # serialize = lambda item: item.getDataForSerialization()
-        # serialized_get = lambda key: serialize(simple_get(key))
 
         getters = []
         for name in self._properties:
@@ -300,8 +296,6 @@ class Info(BaseObject):
         return self._serialize(getters, **kwargs)
 
     def setDataFromSerialization(self, data):
-        from functools import partial
-
         simple_set = partial(setattr, self)
 
         setters = [(name, simple_set) for name in self._properties]

--- a/Lib/defcon/objects/layer.py
+++ b/Lib/defcon/objects/layer.py
@@ -7,6 +7,7 @@ from defcon.objects.glyph import Glyph
 from defcon.objects.lib import Lib
 from defcon.objects.uniData import UnicodeData
 from defcon.objects.color import Color
+from functools import partial
 
 
 class Layer(BaseObject):
@@ -721,7 +722,6 @@ class Layer(BaseObject):
     # -----------------------------
 
     def getDataForSerialization(self, **kwargs):
-        from functools import partial
         simple_get = partial(getattr, self)
         serialize = lambda item: item.getDataForSerialization()
         serialized_get = lambda key: serialize(simple_get(key))
@@ -729,14 +729,12 @@ class Layer(BaseObject):
         getters = (
             ('lib', serialized_get),
             ('color', simple_get),
-            ('glyphs', lambda _: {name:self[name].getDataForSerialization() for name in self.keys()})
+            ('glyphs', lambda _: {name: self[name].getDataForSerialization() for name in self.keys()})
         )
 
         return self._serialize(getters, **kwargs)
 
     def setDataFromSerialization(self, data):
-        from functools import partial
-
         set_attr = partial(setattr, self) # key, data
 
         def set_glyph(name, data):

--- a/Lib/defcon/tools/notifications.py
+++ b/Lib/defcon/tools/notifications.py
@@ -144,11 +144,11 @@ class NotificationCenter(object):
         # -------
         notificationObj = Notification(notification, observableRef, data)
         registryPossibilities = (
-            # most specific -> least specific
-            (notification, observableRef),
-            (notification, None),
+            # least specific -> most specific
+            (None, None),
             (None, observableRef),
-            (None, None)
+            (notification, None),
+            (notification, observableRef),
         )
         for key in registryPossibilities:
             if key not in self._registry:


### PR DESCRIPTION
BaseObject has a selfNotificationCallback that subscribes to all notifications of the object so to destroy representations. This should be called prior to any specific notification.

Reversing the dispatch order does that.

Note: this still means representations haven't been destroyed in the (None, None) and (None, observableRef) cases, but this change alleviates #102 for the more concrete cases.

r? @anthrotype 

cc @typemytype 