### PR TITLE
Make the result of glyph.draw()

### DIFF
--- a/Lib/defcon/objects/glyph.py
+++ b/Lib/defcon/objects/glyph.py
@@ -460,9 +460,9 @@ class Glyph(BaseObject):
         if self._shallowLoadedContours:
             self._drawShallowLoadedContours(pointPen, self._shallowLoadedContours)
         else:
-            for contour in self._contours:
+            for contour in sorted(self._contours):
                 contour.drawPoints(pointPen)
-        for component in self._components:
+        for component in sorted(self._components):
             component.drawPoints(pointPen)
 
     def _drawShallowLoadedContours(self, pointPen, contours):


### PR DESCRIPTION
When creating OTF fonts with ufo2ft, the resulting CharStrings are different across builds due to different contour order. I’m not sure if using sorted is correct here, but it seems to give stable result.