### PR TITLE
fix: use close neighbors in openClosedUniGenerator.py

### DIFF
--- a/tools/openClosedUniGenerator.py
+++ b/tools/openClosedUniGenerator.py
@@ -13,19 +13,13 @@ openValue = None
 for line in text.splitlines():
     line = line.split(";")
     value, name, category = line[:3]
-    if category in ("Ps", "Pe", "Pi", "Pf"):
-        if openValue is None:
+    if category in ("Ps", "Pi"):
             #assert category in ("Ps", "Pi")
             openValue = (value, name, category)
-        else:
-            #assert category in ("Pe", "Pf")
-            if category not in ("Pe", "Pf"):
-                result.append("#%s;%s;%s" % (value, name, category))
-                result.append("")
-            else:
-                result.append("%s;%s;%s" % openValue)
-                result.append("%s;%s;%s" % (value, name, category))
-                result.append("")
-                openValue = None
+    elif category in ("Pe", "Pf") and openValue is not None:
+        result.append("%s;%s;%s" % openValue)
+        result.append("%s;%s;%s" % (value, name, category))
+        result.append("")
+        openValue = None
 
 print("\n".join(result))

--- a/tools/openClosedUniGenerator.py
+++ b/tools/openClosedUniGenerator.py
@@ -14,8 +14,7 @@ for line in text.splitlines():
     line = line.split(";")
     value, name, category = line[:3]
     if category in ("Ps", "Pi"):
-            #assert category in ("Ps", "Pi")
-            openValue = (value, name, category)
+        openValue = (value, name, category)
     elif category in ("Pe", "Pf") and openValue is not None:
         result.append("%s;%s;%s" % openValue)
         result.append("%s;%s;%s" % (value, name, category))


### PR DESCRIPTION
This is to address part of the problems in #140 that some open parentheses do not match the closed ones.
These would only leave special exceptions and ornate parentheses (which is because of reversed order in the data) needed to be appended.