### PR TITLE
Layer: don't load glyphs that are scheduled for deletion

### DIFF
--- a/Lib/defcon/objects/layer.py
+++ b/Lib/defcon/objects/layer.py
@@ -174,7 +174,7 @@ class Layer(BaseObject):
         Load a glyph from the glyph set. This should not be called
         externally, but subclasses may override it for custom behavior.
         """
-        if self._glyphSet is None or name not in self._glyphSet:
+        if self._glyphSet is None or name not in self._glyphSet or name in self._scheduledForDeletion:
             raise KeyError("%s not in layer" % name)
         glyph = self.instantiateGlyphObject()
         glyph.disableNotifications()


### PR DESCRIPTION
Before this patch deleted glyphs would load from disk again upon \_\_getitem__ while \_\_contains__ correctly returned False.

Found this bug while working on fontTools.ufoLib.

r? @anthrotype