### PR TITLE
Implement glyph.correctContourDirection.

### DIFF
--- a/Lib/defcon/objects/contour.py
+++ b/Lib/defcon/objects/contour.py
@@ -525,6 +525,8 @@ class Contour(BaseObject):
         A lower value will yeild higher accuracy but will require
         more computation time.
         """
+        if segmentLength < 1:
+            segmentLength = 1
         # test bounding boxes for intersection
         rect1 = self.bounds
         rect2 = other.bounds
@@ -532,10 +534,8 @@ class Contour(BaseObject):
             return False
         # test existing on curves
         testedPoints = set()
-        haveOffCurves = False
         for point in other:
             if point.segmentType is None:
-                haveOffCurves = True
                 continue
             pt = (point.x, point.y)
             if pt in testedPoints:
@@ -543,14 +543,8 @@ class Contour(BaseObject):
             if not self.pointInside(pt):
                 return False
             testedPoints.add(pt)
-        # if there aren't any off curves,
-        # there isn't anything left to test
-        if not haveOffCurves:
-            return True
-        # flatten curves and test new points
-        if segmentLength < 1:
-            segmentLength = 1
-        flat2 = other.getRepresentation("defcon.contour.flattened", approximateSegmentLength=segmentLength)
+        # flatten into line and test new points
+        flat2 = other.getRepresentation("defcon.contour.flattened", approximateSegmentLength=segmentLength, segmentLines=True)
         for point in flat2:
             pt = (point.x, point.y)
             if pt in testedPoints:

--- a/Lib/defcon/objects/contour.py
+++ b/Lib/defcon/objects/contour.py
@@ -7,7 +7,7 @@ from defcon.objects.base import BaseObject
 from defcon.tools import bezierMath
 from defcon.tools.representations import contourBoundsRepresentationFactory,\
     contourControlPointBoundsRepresentationFactory, contourAreaRepresentationFactory,\
-    contourClockwiseRepresentationFactory, contourFlattenedRepresentationFactor
+    contourFlattenedRepresentationFactor
 from defcon.tools.identifiers import makeRandomIdentifier
 
 
@@ -56,10 +56,6 @@ class Contour(BaseObject):
         ),
         "defcon.contour.area" : dict(
             factory=contourAreaRepresentationFactory,
-            destructiveNotifications=("Contour.PointsChanged")
-        ),
-        "defcon.contour.clockwise" : dict(
-            factory=contourClockwiseRepresentationFactory,
             destructiveNotifications=("Contour.PointsChanged", "Contour.WindingDirectionChanged")
         ),
         "defcon.contour.flattened" : dict(
@@ -415,7 +411,8 @@ class Contour(BaseObject):
     # clockwise
 
     def _get_clockwise(self):
-        return self.getRepresentation("defcon.contour.clockwise")
+        area = self.getRepresentation("defcon.contour.area")
+        return area < 0
 
     def _set_clockwise(self, value):
         if self.clockwise != value:
@@ -452,7 +449,7 @@ class Contour(BaseObject):
     # ----
 
     def _get_area(self):
-        return self.getRepresentation("defcon.contour.area")
+        return abs(self.getRepresentation("defcon.contour.area"))
 
     area = property(_get_area, doc="The area of the contour's outline.")
 

--- a/Lib/defcon/objects/contour.py
+++ b/Lib/defcon/objects/contour.py
@@ -7,7 +7,7 @@ from defcon.objects.base import BaseObject
 from defcon.tools import bezierMath
 from defcon.tools.representations import contourBoundsRepresentationFactory,\
     contourControlPointBoundsRepresentationFactory, contourAreaRepresentationFactory,\
-    contourFlattenedRepresentationFactor
+    contourFlattenedRepresentationFactory
 from defcon.tools.identifiers import makeRandomIdentifier
 
 
@@ -59,7 +59,7 @@ class Contour(BaseObject):
             destructiveNotifications=("Contour.PointsChanged", "Contour.WindingDirectionChanged")
         ),
         "defcon.contour.flattened" : dict(
-            factory=contourFlattenedRepresentationFactor,
+            factory=contourFlattenedRepresentationFactory,
             destructiveNotifications=("Contour.PointsChanged", "Contour.WindingDirectionChanged")
         )
     }

--- a/Lib/defcon/tools/representations.py
+++ b/Lib/defcon/tools/representations.py
@@ -2,7 +2,6 @@ from __future__ import absolute_import
 from fontTools.pens.areaPen import AreaPen
 from fontTools.pens.boundsPen import ControlBoundsPen, BoundsPen
 from fontTools.misc.arrayTools import unionRect
-from fontPens.flattenPen import FlattenPen
 
 # -----
 # Glyph
@@ -48,7 +47,8 @@ def contourAreaRepresentationFactory(contour):
 
 # flattened
 
-def contourFlattenedRepresentationFactor(contour, approximateSegmentLength=5):
+def contourFlattenedRepresentationFactory(contour, approximateSegmentLength=5):
+    from fontPens.flattenPen import FlattenPen
     from defcon.objects.glyph import Glyph
     contourClass = contour.__class__
     glyph = Glyph(contourClass=contourClass)

--- a/Lib/defcon/tools/representations.py
+++ b/Lib/defcon/tools/representations.py
@@ -2,6 +2,7 @@ from __future__ import absolute_import
 from fontTools.pens.areaPen import AreaPen
 from fontTools.pens.boundsPen import ControlBoundsPen, BoundsPen
 from fontTools.misc.arrayTools import unionRect
+from fontPens.flattenPen import FlattenPen
 
 # -----
 # Glyph
@@ -43,15 +44,7 @@ def contourControlPointBoundsRepresentationFactory(obj):
 def contourAreaRepresentationFactory(contour):
     pen = AreaPen()
     contour.draw(pen)
-    return abs(pen.value)
-
-# winding direction
-
-def contourClockwiseRepresentationFactory(contour):
-    pen = AreaPen()
-    pen.endPath = pen.closePath
-    contour.draw(pen)
-    return pen.value < 0
+    return pen.value
 
 # flattened
 

--- a/Lib/defcon/tools/representations.py
+++ b/Lib/defcon/tools/representations.py
@@ -7,16 +7,6 @@ from fontTools.misc.arrayTools import unionRect
 # Glyph
 # -----
 
-def glyphBoundsRepresentationFactory(glyph):
-    pen = BoundsPen(glyph.layer)
-    glyph.draw(pen)
-    return pen.bounds
-
-def glyphControlPointBoundsRepresentationFactory(glyph):
-    pen = ControlBoundsPen(glyph.layer)
-    glyph.draw(pen)
-    return pen.bounds
-
 def glyphAreaRepresentationFactory(glyph):
     pen = AreaPen()
     glyph.draw(pen)

--- a/Lib/defcon/tools/representations.py
+++ b/Lib/defcon/tools/representations.py
@@ -17,6 +17,11 @@ def glyphControlPointBoundsRepresentationFactory(glyph):
     glyph.draw(pen)
     return pen.bounds
 
+def glyphAreaRepresentationFactory(glyph):
+    pen = AreaPen()
+    glyph.draw(pen)
+    return abs(pen.value)
+
 # -------
 # Contour
 # -------
@@ -33,6 +38,13 @@ def contourControlPointBoundsRepresentationFactory(obj):
     obj.draw(pen)
     return pen.bounds
 
+# area
+
+def contourAreaRepresentationFactory(contour):
+    pen = AreaPen()
+    contour.draw(pen)
+    return abs(pen.value)
+
 # winding direction
 
 def contourClockwiseRepresentationFactory(contour):
@@ -40,6 +52,18 @@ def contourClockwiseRepresentationFactory(contour):
     pen.endPath = pen.closePath
     contour.draw(pen)
     return pen.value < 0
+
+# flattened
+
+def contourFlattenedRepresentationFactor(contour, approximateSegmentLength=5):
+    from defcon.objects.glyph import Glyph
+    contourClass = contour.__class__
+    glyph = Glyph(contourClass=contourClass)
+    outputPen = glyph.getPen()
+    flattenPen = FlattenPen(outputPen, approximateSegmentLength=approximateSegmentLength)
+    contour.draw(flattenPen)
+    output = glyph[0]
+    return output
 
 # ---------
 # Component

--- a/Lib/defcon/tools/representations.py
+++ b/Lib/defcon/tools/representations.py
@@ -47,13 +47,13 @@ def contourAreaRepresentationFactory(contour):
 
 # flattened
 
-def contourFlattenedRepresentationFactory(contour, approximateSegmentLength=5):
+def contourFlattenedRepresentationFactory(contour, approximateSegmentLength=5, segmentLines=False):
     from fontPens.flattenPen import FlattenPen
     from defcon.objects.glyph import Glyph
     contourClass = contour.__class__
     glyph = Glyph(contourClass=contourClass)
     outputPen = glyph.getPen()
-    flattenPen = FlattenPen(outputPen, approximateSegmentLength=approximateSegmentLength)
+    flattenPen = FlattenPen(outputPen, approximateSegmentLength=approximateSegmentLength, segmentLines=segmentLines)
     contour.draw(flattenPen)
     output = glyph[0]
     return output


### PR DESCRIPTION
This required several other properties and methods. See robofab-developers/fontParts#146 for more background.