### PR TITLE
fix saving new font or "saving as" to preexisting path

### DIFF
--- a/Lib/defcon/objects/layerSet.py
+++ b/Lib/defcon/objects/layerSet.py
@@ -283,6 +283,8 @@ class LayerSet(BaseObject):
                     newName = actionData["newName"]
                     if oldName in writer.layerContents:
                         writer.renameGlyphSet(oldName, newName)
+                        if newName == self.defaultLayer.name:
+                            writer.renameGlyphSet(newName, newName, defaultLayer=True)
                 elif action == "default":
                     newDefault = actionData["newDefault"]
                     oldDefault = actionData["oldDefault"]

--- a/Lib/defcon/test/objects/test_font.py
+++ b/Lib/defcon/test/objects/test_font.py
@@ -103,7 +103,6 @@ class FontTest(unittest.TestCase):
         self.assertEqual(sorted(fileNames), ["B_.glif", "C_.glif"])
         with self.assertRaises(KeyError):
             del font["NotInFont"]
-        tearDownTestFontCopy()
 
     def test_delitem_glyph_not_dirty(self):
         path = makeTestFontCopy()
@@ -122,7 +121,6 @@ class FontTest(unittest.TestCase):
         del font["A"]
         font.save()
         self.assertFalse(os.path.exists(glyphPath))
-        tearDownTestFontCopy()
 
     def test_delitem_glyph_dirty(self):
         path = makeTestFontCopy()
@@ -142,7 +140,6 @@ class FontTest(unittest.TestCase):
         del font["A"]
         font.save()
         self.assertFalse(os.path.exists(glyphPath))
-        tearDownTestFontCopy()
 
     def test_len(self):
         font = Font(getTestFontPath())
@@ -403,7 +400,6 @@ class FontTest(unittest.TestCase):
         fileNames = glob.glob(os.path.join(path, 'glyphs', '*.glif'))
         fileNames = [os.path.basename(fileName) for fileName in fileNames]
         self.assertEqual(sorted(fileNames), ["A_.glif", "B_.glif", "C_.glif"])
-        tearDownTestFontCopy()
 
     def test_save_as(self):
         path = getTestFontPath()

--- a/Lib/defcon/test/objects/test_layerSet.py
+++ b/Lib/defcon/test/objects/test_layerSet.py
@@ -4,7 +4,9 @@ import shutil
 from ufoLib import UFOReader
 from defcon import Font
 from defcon.test.testTools import (
-    getTestFontPath, makeTestFontCopy, tearDownTestFontCopy)
+    getTestFontPath, getTestFontCopyPath, makeTestFontCopy,
+    tearDownTestFontCopy)
+
 
 try:
     from plistlib import load, dump
@@ -18,6 +20,10 @@ class LayerTest(unittest.TestCase):
         unittest.TestCase.__init__(self, methodName)
         if not hasattr(self, "assertRaisesRegex"):
             self.assertRaisesRegex = self.assertRaisesRegexp
+
+    def tearDown(self):
+        if os.path.exists(getTestFontCopyPath()):
+            tearDownTestFontCopy()
 
     def test_set_parent_data_in_layer(self):
         font = Font(getTestFontPath())
@@ -90,7 +96,6 @@ class LayerTest(unittest.TestCase):
         font.save()
         self.assertFalse(os.path.exists(os.path.join(path, "A_.glif")))
         self.assertTrue(os.path.exists(os.path.join(path, "B_.glif")))
-        tearDownTestFontCopy()
 
     def test_len(self):
         font = Font(getTestFontPath())
@@ -311,6 +316,16 @@ class LayerTest(unittest.TestCase):
         self.assertEqual(layers.layerOrder,
                          ["public.default", "Name Change Test", "Layer 1"])
         self.assertTrue(layer.dirty)
+
+    def test_rename_default_layer(self):
+        # https://github.com/unified-font-object/ufoLib/issues/123
+        path = getTestFontCopyPath()
+        font = Font()
+        font.save(path)
+        font.layers.defaultLayer.name = "somethingElse"
+        font.save()
+        self.assertEqual(Font(path).layers.defaultLayer.name, "somethingElse")
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
When saving a UFO (either created from scratch, or loaded from a different path) to the location of an existing UFO, the entire directory needs to be removed before saving the new one.

Fixes googlei18n/fontmake#372

Also, raise a DefconError when attempting to save a new font (i.e. not loaded from disk) without passing 'path' argument to `save()` metohd.

