### PR TITLE
Don't store representations in objects without a dispatcher.

### DIFF
--- a/Lib/defcon/objects/base.py
+++ b/Lib/defcon/objects/base.py
@@ -299,15 +299,22 @@ class BaseObject(object):
         representation name. **\*\*kwargs** will be passed
         to the appropriate representation factory.
         """
-        if name not in self._representations:
-            self._representations[name] = {}
-        representations = self._representations[name]
-        subKey = self._makeRepresentationSubKey(**kwargs)
-        if subKey not in representations:
+        # only store the representation if the object has a
+        # dispatcher. otherwise, notifications may not be
+        # destroyed after an object change.
+        if self.dispatcher is None:
             factory = self.representationFactories[name]
-            representation = factory["factory"](self, **kwargs)
-            representations[subKey] = representation
-        return representations[subKey]
+            return factory["factory"](self, **kwargs)
+        else:
+            if name not in self._representations:
+                self._representations[name] = {}
+            representations = self._representations[name]
+            subKey = self._makeRepresentationSubKey(**kwargs)
+            if subKey not in representations:
+                factory = self.representationFactories[name]
+                representation = factory["factory"](self, **kwargs)
+                representations[subKey] = representation
+            return representations[subKey]
 
     def destroyRepresentation(self, name, **kwargs):
         """

--- a/Lib/defcon/test/objects/test_base.py
+++ b/Lib/defcon/test/objects/test_base.py
@@ -124,6 +124,8 @@ class RepresentationsTest(unittest.TestCase):
         del self.obj
 
     def test_object_representations(self):
+        notificationCenter = NotificationCenter()
+        self.obj._dispatcher = weakref.ref(notificationCenter)
         self.obj.representationFactories = dict(
             test=dict(
                 factory=_representationTestFactory,
@@ -178,6 +180,16 @@ class RepresentationsTest(unittest.TestCase):
         self.assertEqual(self.obj.representationKeys(),
                          [('foo', {})])
 
+    def test_object_representations_no_dispatcher(self):
+        self.obj.representationFactories = dict(
+            test=dict(
+                factory=_representationTestFactory,
+                destructiveNotifications=["BaseObject.Changed"]))
+        self.assertEqual(self.obj.getRepresentation("test"), "()")
+        self.assertEqual(
+            [],
+            []
+        )
 
 class TestBaseDictObject(BaseDictObject):
 


### PR DESCRIPTION
See #182 for details on why this is needed. This will close #182.