### PR TITLE
Fix Glyph.correctContourDirection() crash on Py3 when contours have same area

### DIFF
--- a/Lib/defcon/objects/glyph.py
+++ b/Lib/defcon/objects/glyph.py
@@ -642,9 +642,8 @@ class Glyph(BaseObject):
         # set the contours to the same direction
         for contour in self:
             contour.clockwise = False
-        # sort the contours by area
-        contours = [(contour.area, contour) for contour in self]
-        contours = [contour for (area, contour) in reversed(sorted(contours))]
+        # sort the contours by area in reverse (i.e. largest first)
+        contours = sorted(self, key=lambda contour: -contour.area)
         # build a tree of nested contours
         tree = {}
         for largeIndex, largeContour in enumerate(contours):

--- a/Lib/defcon/test/objects/test_contour.py
+++ b/Lib/defcon/test/objects/test_contour.py
@@ -377,6 +377,25 @@ class ContourTest(unittest.TestCase):
         contour.identifier = None
         self.assertEqual(contour.identifier, "contour 2")
         self.assertEqual(sorted(glyph.identifiers), ["contour 1", "contour 2"])
+    
+    def test_correct_direction_same_area(self):
+        glyph = Glyph()
+        pen = glyph.getPointPen()
+        pen.beginPath()
+        pen.addPoint((0, 0), segmentType="line")
+        pen.addPoint((0, 50), segmentType="line")
+        pen.addPoint((50, 50), segmentType="line")
+        pen.endPath()
+        pen.beginPath()
+        pen.addPoint((50, 50), segmentType="line")
+        pen.addPoint((50, 100), segmentType="line")
+        pen.addPoint((100, 100), segmentType="line")
+        pen.endPath()
+        try:
+            glyph.correctContourDirection()
+        except Exception as e:
+            self.fail("glyph.correctContourDirection() raised unexpected exception: "
+                      + str(e))
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
E.g. when the glyph for the Turkish Lira has two identical stroke contours. Seems to not bother Python 2. Fixes https://github.com/typesupply/defcon/issues/197.